### PR TITLE
Convert - to _ in config params

### DIFF
--- a/src/dclick/command.py
+++ b/src/dclick/command.py
@@ -7,7 +7,7 @@ import warnings
 
 class CommandWithConfig(click.Command):
 
-    SPECIAL_CHARACTERS = ["!", "?", ".", "-", ":", "/"]
+    SPECIAL_CHARACTERS = ["!", "?", ".", ":", "/"]
 
     def __init__(self, config_filepath: str = "train_config.yml", *args, **kwargs):
         super(CommandWithConfig, self).__init__(*args, **kwargs)
@@ -20,6 +20,7 @@ class CommandWithConfig(click.Command):
         :return:
         """
         config_params = self._parse_config()
+        config_params = self.convert_underscores(config_params)
         self.check_config_params(config_params)
         for param_index, (param_name, param_value) in enumerate(ctx.params.items()):
             if not param_value:  # Default is empty, set value in config
@@ -92,10 +93,13 @@ class CommandWithConfig(click.Command):
             warnings.warn(
                 "The parameter name %s in %s contains the following special characters %s,\
 this might be an issue\n\
-Note: '-' in click are converted to '_'"
+Note: '-' are converted to '_'"
                 % (param_name, self.config_filepath, special_characters_in_param_name)
             )
 
     def check_config_params(self, config_params):
         for param_name in config_params:
             self.check_characters_in_param_name(param_name)
+
+    def convert_underscores(self, config_params):
+        return {key.replace("-", "_"): value for key, value in config_params.items()}

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -51,16 +51,16 @@ def test__parse_config_should_return_a_dict_of_parameters_given_a_json_file(tmpd
 
 def test_check_config_params_should_raise_a_warning_when_given_special_characters(tmpdir):
     # Given
-    content = {"n-epochs": 1}
+    content = {"n-epochs!?": 1}
     config_filepath = os.path.join(tmpdir, "test_config.yml")
     with open(config_filepath, "w") as config_file:
         yaml.dump(content, config_file)
     test_command = CommandWithConfig(config_filepath, "special_character_config")
     expected_message = (
-        "The parameter name n-epochs in %s contains \
-the following special characters ['-'],\
+        "The parameter name n-epochs!? in %s contains \
+the following special characters ['!', '?'],\
 this might be an issue\n\
-Note: '-' in click are converted to '_'"
+Note: '-' are converted to '_'"
         % config_filepath
     )
     # When

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -139,7 +139,7 @@ def test_command_with_non_existing_path_should_fail(tmpdir):
 def test_command_with_paramater_name_including_underscore(tmpdir):
     # Given
     config_filepath = os.path.join(tmpdir, "test_config.yml")
-    content = {"n_epochs": 1}
+    content = {"n-epochs": 1}
     with open(config_filepath, "w") as config_file:
         yaml.dump(content, config_file)
 


### PR DESCRIPTION
click converts '-' to '_' because '_' are not handled by the cli and '-' are not handled by python. If a parameter name contains a '-' in dclick then it is automatically converted to an underscore '_'. It raises a warning to notice the user.